### PR TITLE
7 create and link contact us page (closes 7)

### DIFF
--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -36,6 +36,7 @@ export function ContactPage() {
                                 <select
                                     id="topic"
                                     name="topic"
+                                    required
                                     className="mt-2 block w-full rounded-md py-2 px-3 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50">
                                     <option value="">Select an option</option>
                                     <option value="general">General Inquiry</option>

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -22,7 +22,14 @@ export function ContactPage() {
                             <div>
 
                                 <label htmlFor="name" className="block text-sm font-medium text-gray-800">Name</label>
-                                <input type="text" id="name" name="name" placeholder="Full name" required className="mt-2 block w-full rounded-md py-2 px-3 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50" />
+                                <input 
+                                    type="text" 
+                                    id="name" 
+                                    name="name" 
+                                    placeholder="Full name" 
+                                    required 
+                                    className="mt-2 block w-full rounded-md py-2 px-3 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50"
+                                 />
                             </div>
                             <div>
                             <label htmlFor="topic" className="block text-sm font-medium text-gray-800">Topic</label>
@@ -38,7 +45,14 @@ export function ContactPage() {
                             </div>
                             <div>
                                 <label htmlFor="email" className="block text-sm font-medium text-gray-700">Email</label>
-                                <input type="email" id="email" name="email" placeholder="email@example.com" required className="mt-2 block w-full rounded-md py-2 px-3 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50" />
+                                <input 
+                                    type="email" 
+                                    id="email" 
+                                    name="email" 
+                                    placeholder="email@example.com" 
+                                    required 
+                                    className="mt-2 block w-full rounded-md py-2 px-3 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50" 
+                                />
                             </div>
                             <div>
                                 <label htmlFor="message" className="block text-sm font-medium text-gray-700">Message</label>

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -39,9 +39,11 @@ export function ContactPage() {
                                     required
                                     className="mt-2 block w-full rounded-md py-2 px-3 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50">
                                     <option value="">Select an option</option>
-                                    <option value="general">General Inquiry</option>
-                                    <option value="support">Support</option>
+                                    <option value="media">Media Inquiry</option>
+                                    <option value="partnership">Partnership Opportunity</option>
+                                    <option value="support">Technical Support</option>
                                     <option value="feedback">Feedback</option>
+                                    <option value="other">Other</option>
                                 </select>
                             </div>
                             <div>

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -22,15 +22,34 @@ export function ContactPage() {
                             <div>
 
                                 <label htmlFor="name" className="block text-sm font-medium text-gray-800">Name</label>
-                                <input type="text" id="name" name="name" required className="mt-2 block w-full rounded-md py-2 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50" />
+                                <input type="text" id="name" name="name" placeholder="Full name" required className="mt-2 block w-full rounded-md py-2 px-3 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50" />
+                            </div>
+                            <div>
+                            <label htmlFor="topic" className="block text-sm font-medium text-gray-800">Topic</label>
+                                <select
+                                    id="topic"
+                                    name="topic"
+                                    className="mt-2 block w-full rounded-md py-2 px-3 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50">
+                                    <option value="">Select an option</option>
+                                    <option value="general">General Inquiry</option>
+                                    <option value="support">Support</option>
+                                    <option value="feedback">Feedback</option>
+                                </select>
                             </div>
                             <div>
                                 <label htmlFor="email" className="block text-sm font-medium text-gray-700">Email</label>
-                                <input type="email" id="email" name="email" required className="mt-1 block w-full rounded-md py-2 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50" />
+                                <input type="email" id="email" name="email" placeholder="email@example.com" required className="mt-2 block w-full rounded-md py-2 px-3 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50" />
                             </div>
                             <div>
                                 <label htmlFor="message" className="block text-sm font-medium text-gray-700">Message</label>
-                                <input type="text" id="message" name="message" required className="mt-1 block w-full rounded-md py-10 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50 " />
+                                <textarea
+                                    id="message"
+                                    name="message"
+                                    placeholder = "Let us know what you think!"
+                                    required
+                                    rows={5}
+                                    className="mt-2 block w-full rounded-md px-3 py-2 border-gray-300 shadow-sm focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50"
+                                />
                             </div>
                             <Button type="submit" className="bg-purple-600 hover:bg-purple-700 text-white font-medium py-2 px-4 rounded-md">
                                 Send Message


### PR DESCRIPTION
Updated mentor page! 

- Adjusted horizontal padding to make text boxes feel more natural
- changed message from input to text area, which allows for multiple lines and feels more natural for a message
- added a drop-down menu with (placeholder, possibly) options
- added placeholder text to text input boxes for a more natural feel
- in the code, light reformatting for readability (with no output change)